### PR TITLE
tag that uses slash as part of the style will not be replaced to <div/>

### DIFF
--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ const processEmailable = function (args, html) {
   const options = {
     removeStyleTags: true,
     removeLinkTags: true,
-    removeHtmlSelectors: true,
+    removeHtmlSelectors: false,
     url: `file:///${path}/`
   };
 

--- a/index.js
+++ b/index.js
@@ -136,7 +136,7 @@ const processEmailable = function (args, html) {
   const options = {
     removeStyleTags: true,
     removeLinkTags: true,
-    removeHtmlSelectors: false,
+    removeHtmlSelectors: true,
     url: `file:///${path}/`
   };
 

--- a/lib/sanitize-html.js
+++ b/lib/sanitize-html.js
@@ -89,15 +89,15 @@ const DEFAULT_REPLACE_WITH_RULES = [
  * @type {{re: RegExp, kind: number}[]}
  */
 const htmlTagRegularExpressions = [
+  // self close tag, it may have additional attributes and may span multiple lines. Evaluate this before open tag, the two have similarity.
+  {
+    re: /<\s*([a-zA-z_:][0-9a-zA-Z_:.-]+)[^>]*\/\s*>/m,
+    kind: TagKind.SelfClose
+  },
   // open tag, it may have additional attributes and may span multiple lines.
   {
-    re: /<\s*([a-zA-z_:][0-9a-zA-Z_:.-]+)[^>/]*>/m,
+    re: /<\s*([a-zA-z_:][0-9a-zA-Z_:.-]+)[^>]*>/m,
     kind: TagKind.Open
-  },
-  // self close tag, it may have additional attributes and may span multiple lines.
-  {
-    re: /<\s*([a-zA-z_:][0-9a-zA-Z_:.-]+)[^>/]*\/\s*>/m,
-    kind: TagKind.SelfClose
   },
   // close tag
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-universalize-email",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/sanitize-html-spec.js
+++ b/test/sanitize-html-spec.js
@@ -93,4 +93,9 @@ describe('sanitize-html', () => {
     const html = '<nue-aq><nue-ab> something </nue-ab></nue-aq>';
     expect(sanitizeHtml(html)).toEqual("<< something >>");
   });
+
+  it('should handle slash in attributes', () => {
+    const html = '<foo style="font:foo/font;"> something </foo>'
+    expect(sanitizeHtml(html)).toEqual('<div style="font:foo/font;"> something </div>');
+  })
 });


### PR DESCRIPTION
Find self closing tag before opening tag. This allows us no longer have to skip slash in tag attributes. So slash can be handled correctly.